### PR TITLE
add context to external auth requests

### DIFF
--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -348,6 +348,9 @@ http {
             proxy_set_header            X-Original-URI $request_uri;
             proxy_set_header            X-Scheme       $pass_access_scheme;
             {{ end }}
+            {{ if not (empty $location.ExternalAuth.Context) }}
+            proxy_set_header            X-Context       {{ $location.ExternalAuth.Context }};
+            {{ end }}
             proxy_pass_request_headers  on;
             proxy_set_header            Host {{ $location.ExternalAuth.Host }};
             proxy_ssl_server_name       on;

--- a/core/pkg/ingress/annotations/authreq/main.go
+++ b/core/pkg/ingress/annotations/authreq/main.go
@@ -31,6 +31,7 @@ const (
 	// external URL that provides the authentication
 	authURL       = "ingress.kubernetes.io/auth-url"
 	authSigninURL = "ingress.kubernetes.io/auth-signin"
+	authContext   = "ingress.kubernetes.io/auth-context"
 	authMethod    = "ingress.kubernetes.io/auth-method"
 	authBody      = "ingress.kubernetes.io/auth-send-body"
 	authHeaders   = "ingress.kubernetes.io/auth-response-headers"
@@ -42,6 +43,7 @@ type External struct {
 	// Host contains the hostname defined in the URL
 	Host            string   `json:"host"`
 	SigninURL       string   `json:"signinUrl"`
+	Context         string   `json:"context"`
 	Method          string   `json:"method"`
 	SendBody        bool     `json:"sendBody"`
 	ResponseHeaders []string `json:"responseHeaders,omitEmpty"`
@@ -171,10 +173,12 @@ func (a authReq) Parse(ing *extensions.Ingress) (interface{}, error) {
 	}
 
 	sb, _ := parser.GetBoolAnnotation(authBody, ing)
+	ctx, _ := parser.GetStringAnnotation(authContext, ing)
 
 	return &External{
 		URL:             str,
 		Host:            ur.Hostname(),
+		Context:         ctx,
 		SigninURL:       signin,
 		Method:          m,
 		SendBody:        sb,


### PR DESCRIPTION
This patch allows to pass data, using annotations, from the ingress resource to the external auth backend by using an header "X-Context"

By doing so, we can give a context to an auth[entication|orization] request and, from that, (at least) manage authorizations in addition to authentication.

For instance, we're using it in order to map the request to an actual application so 
the external auth backend can then deliver authorizations based on the identity of the authenticated user and of the requested application.